### PR TITLE
Got API returning correct postcode ID now

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,8 @@
 class RegistrationsController < Devise::RegistrationsController
 
   def create
-    build_resource(user_params)
+    user_params_w_postcode = user_params.merge!({ postcode: Postcode.find_by(code: user_params[:postcode]) })
+    build_resource(user_params_w_postcode)
     
     if user_params.key? :profile_image
       resource.profile_image.attach(data: user_params[:profile_image])
@@ -14,9 +15,10 @@ class RegistrationsController < Devise::RegistrationsController
   protected
 
   def user_params
-    params.require(:user)
+    params
+      .require(:user)
       .permit(:email, :password, :password_confirmation, :first_name, :last_name, 
-              :last_seen, :sex, :age, :biography, :hourly_rate, 
+              :last_seen, :sex, :age, :biography, :hourly_rate, :postcode,
               :max_distance_available, :profile_image, :type)
   end
 

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -31,7 +31,7 @@ describe 'POST /signup', type: :request do
 
         city: tutor_attrs[:city],
 
-        postcode: { id: postcode.id },
+        postcode: postcode.code,
 
         subject: tutor_attrs[:subject]
       }
@@ -68,6 +68,15 @@ describe 'POST /signup', type: :request do
 
       it "saves and returns the age" do
         expect(response_json['attributes']['age']).to eq tutor_attrs[:age]
+      end
+    end
+
+    describe "just regular user relationships" do
+
+      before { post '/signup', params: params }
+
+      it "saves and returns the postcode ID" do
+        expect(response_json['relationships']['postcode']['data']['id']).to eq postcode.id
       end
     end
 


### PR DESCRIPTION
Okay! We'd had a slight bug with our create-Tutor API endpoint: the code present basically just assumed that a `postcode` was just simply a regular old User attribute ... but of course it was not, was it. No. A Postcode is a fully-fledged ActiveRecord object, and the actual four-digit code itself is a `code` attribute. To fix this, I added a teensy bit of extra API endpoint controller code that performs a Postcode search, and attaches an actual corresponding Postcode object to `user_params`. And tests too, naturally.

One caveat: The API response now returns the ActiveRecord object in standard json-api format, meaning it returns that Postcode object's ID, and not the actual postcode. So ... we could either add another endpoint that returns the Postcode object in total, including its code - or, from memory, I believe the json-api format allows us to either attach the entire Postcode object to `relationships` instead of just the ID, or, a json-api response has an associated flat collection of full JSON objects, and the assumption is that the client will receive this ID and do its own querying with the associated objects. Either-or. As I type this, the former actually seems a tad more reasonable. For now.