### PR TITLE
Feature/37 postcode json

### DIFF
--- a/app/controllers/tutors_controller.rb
+++ b/app/controllers/tutors_controller.rb
@@ -100,10 +100,10 @@ class TutorsController < ApplicationController
     end
 
     if errors.length > 0
-          render json: {
-      status: "A cheapass like you can't afford me, can you, #{ Faker.any_character }, not with JSON that invalid",
-      error: errors 
-    }.to_json, status: 402
+      render json: {
+        status: "A cheapass like you can't afford me, can you, #{ Faker.any_character }, not with JSON that invalid",
+        error: errors 
+      }.to_json, status: 402
     end
   end
 

--- a/app/models/language_user.rb
+++ b/app/models/language_user.rb
@@ -5,20 +5,22 @@ class LanguageUser < ApplicationRecord
 
   def as_json(params={})
     {
-      id: id,
-      type: 'language_users',
-      attributes: {},
-      relationships: {
-        language: {
-          data: {
-            id: language.id,
-            type: 'languages',
-          }
-        },
-        user: {
-          data: {
-            id: user.id,
-            type: 'users'
+      data: {
+        id: id,
+        type: 'language_users',
+        attributes: {},
+        relationships: {
+          language: {
+            data: {
+              id: language.id,
+              type: 'languages',
+            }
+          },
+          user: {
+            data: {
+              id: user.id,
+              type: 'users'
+            }
           }
         }
       }

--- a/app/models/postcode.rb
+++ b/app/models/postcode.rb
@@ -4,4 +4,21 @@ class Postcode < ApplicationRecord
 
   acts_as_mappable lat_column_name: :latitude, 
                    lng_column_name: :longitude
+
+  def as_json(params={})
+  	{
+  	  data: {
+	  	id: id,
+	  	type: 'postcodes',
+	  	attributes: { 
+		  code: code,
+		  county: county,
+		  latitude: latitude,
+		  longitude: longitude,
+		  name: name,
+		  state: state
+        }
+	  }
+    }
+  end
 end

--- a/app/models/saved_profile.rb
+++ b/app/models/saved_profile.rb
@@ -11,20 +11,22 @@ class SavedProfile < ApplicationRecord
 
   def as_json(params={})
     {
-      id: id,
-      type: 'saved_profiles',
-      attributes: {},
-      relationships: {
-        saver: {
-          data: {
-            id: saver.id,
-            type: 'students',
-          }
-        },
-        savee: {
-          data: {
-            id: savee.id,
-            type: 'tutors',
+      data: {
+        id: id,
+        type: 'saved_profiles',
+        attributes: {},
+        relationships: {
+          saver: {
+            data: {
+              id: saver.id,
+              type: 'students',
+            }
+          },
+          savee: {
+            data: {
+              id: savee.id,
+              type: 'tutors',
+            }
           }
         }
       }

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -13,44 +13,44 @@ class Student < User
 
   def as_json(params={})
     super.deep_merge({
-      type: 'students',
-      attributes: {
-
-      },
-      relationships: { 
-        saved_profiles: {
-          data: saved_profiles.map do |saved_profile|
-              {
-                type: 'saved_profiles',
-                id: saved_profile.id,
-              }
-            end
+      data: {
+        type: 'students',
+        attributes: {},
+        relationships: { 
+          saved_profiles: {
+            data: saved_profiles.map do |saved_profile|
+                {
+                  type: 'saved_profiles',
+                  id: saved_profile.id,
+                }
+              end
+          },
+          saved_tutors: {
+            data: saved_tutors.map do |saved_tutor|
+                {
+                  type: 'saved_tutors',
+                  id: saved_tutor.id,
+                }
+              end
+          },
+          student_subjects: {
+            data: student_subjects.map do |student_subject|
+                {
+                  type: 'student_subjects',
+                  id: student_subject.id,
+                }
+              end
+          },
+          reviews: {
+            data: reviews.map do |review|
+                {
+                  type: 'reviews',
+                  id: review.id,
+                }
+              end
+          },
         },
-        saved_tutors: {
-          data: saved_tutors.map do |saved_tutor|
-              {
-                type: 'saved_tutors',
-                id: saved_tutor.id,
-              }
-            end
-        },
-        student_subjects: {
-          data: student_subjects.map do |student_subject|
-              {
-                type: 'student_subjects',
-                id: student_subject.id,
-              }
-            end
-        },
-        reviews: {
-          data: reviews.map do |review|
-              {
-                type: 'reviews',
-                id: review.id,
-              }
-            end
-        },
-      },
+      }
     })
   end
 end

--- a/app/models/student_subject.rb
+++ b/app/models/student_subject.rb
@@ -5,20 +5,22 @@ class StudentSubject < ApplicationRecord
 
   def as_json(params={})
     {
-      id: 'id',
-      type: 'student_subjects',
-      attributes: {},
-      relationships: {
-        student: {
-          data: {
-            id: student.id,
-            type: 'students',
-          }
-        },
-        subject: {
-          data: {
-            id: subject.id,
-            type: 'subjects'
+      data: {
+        id: 'id',
+        type: 'student_subjects',
+        attributes: {},
+        relationships: {
+          student: {
+            data: {
+              id: student.id,
+              type: 'students',
+            }
+          },
+          subject: {
+            data: {
+              id: subject.id,
+              type: 'subjects'
+            }
           }
         }
       }

--- a/app/models/subject_tutor.rb
+++ b/app/models/subject_tutor.rb
@@ -5,20 +5,22 @@ class SubjectTutor < ApplicationRecord
 
   def as_json(params={})
     {
-      id: 'id',
-      type: 'subject_tutors',
-      attributes: {},
-      relationships: {
-        subject: {
-          data: {
-            id: subject.id,
-            type: 'subjects',
-          }
-        },
-        tutor: {
-          data: {
-            id: tutor.id,
-            type: 'tutors'
+      data: {
+        id: 'id',
+        type: 'subject_tutors',
+        attributes: {},
+        relationships: {
+          subject: {
+            data: {
+              id: subject.id,
+              type: 'subjects',
+            }
+          },
+          tutor: {
+            data: {
+              id: tutor.id,
+              type: 'tutors'
+            }
           }
         }
       }

--- a/app/models/tutor.rb
+++ b/app/models/tutor.rb
@@ -63,29 +63,31 @@ class Tutor < User
 
   def as_json(params={})
     super.deep_merge({
-      type: 'tutors',
-      attributes: {
-        max_distance_available: max_distance_available,
-        hourly_rate: hourly_rate,
-        biography: biography,
-      },
-      relationships: {
-        tutor_availabilities: {
-          data: tutor_availabilities.map do |tutor_availability|
-              {
-                type: 'tutor_availabilities',
-                id: tutor_availability.id,
-              } 
-            end
+      data: {
+        type: 'tutors',
+        attributes: {
+          max_distance_available: max_distance_available,
+          hourly_rate: hourly_rate,
+          biography: biography,
         },
-        subject_tutors: {
-          data: subject_tutors.map do |subject_tutor|
-              {
-                type: 'subject_tutors',
-                id: subject_tutor.id,
-              }
-            end
-        },
+        relationships: {
+          tutor_availabilities: {
+            data: tutor_availabilities.map do |tutor_availability|
+                {
+                  type: 'tutor_availabilities',
+                  id: tutor_availability.id,
+                } 
+              end
+          },
+          subject_tutors: {
+            data: subject_tutors.map do |subject_tutor|
+                {
+                  type: 'subject_tutors',
+                  id: subject_tutor.id,
+                }
+              end
+          },
+        }
       }
     })
   end

--- a/app/models/tutor_availability.rb
+++ b/app/models/tutor_availability.rb
@@ -5,20 +5,22 @@ class TutorAvailability < ApplicationRecord
 
   def as_json(params={})
     {
-      id: 'id',
-      type: 'tutor_availabilities',
-      attributes: {},
-      relationships: {
-        tutor: {
-          data: {
-            id: tutor.id,
-            type: 'tutors',
-          }
-        },
-        availability: {
-          data: {
-            id: availability.id,
-            type: 'availabilities'
+      data: {
+        id: 'id',
+        type: 'tutor_availabilities',
+        attributes: {},
+        relationships: {
+          tutor: {
+            data: {
+              id: tutor.id,
+              type: 'tutors',
+            }
+          },
+          availability: {
+            data: {
+              id: availability.id,
+              type: 'availabilities'
+            }
           }
         }
       }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,44 +27,49 @@ class User < ApplicationRecord
   acts_as_mappable through: :postcode
 
   def as_json(params={})
-    { 
-      id: id,
-      type: 'users',
-      attributes: {
-        created_at: created_at,
-        updated_at: updated_at,
-        email: email,
-        first_name: first_name,
-        last_name: last_name,
-        sex: sex,
-        age: age,
-        last_seen: last_seen,
-        profile_image_path: if profile_image.blank?
-            nil
-          else
-            rails_blob_path(profile_image, only_path: true)
-          end
-      },
-      relationships: {
-        language_users: {
-          data: language_users.map do |language_user|
-              {
-                type: 'language_users',
-                id: language_user.id,
-              }
+    {
+      data: { 
+        id: id,
+        type: 'users',
+        attributes: {
+          created_at: created_at,
+          updated_at: updated_at,
+          email: email,
+          first_name: first_name,
+          last_name: last_name,
+          sex: sex,
+          age: age,
+          last_seen: last_seen,
+          profile_image_path: if profile_image.blank?
+              nil
+            else
+              rails_blob_path(profile_image, only_path: true)
             end
         },
-        postcode: { 
-          data: if postcode 
-              {
-                type: 'postcodes',
-                id: postcode.id 
+        relationships: {
+          language_users: {
+            data: language_users.map do |language_user|
+                {
+                  type: 'language_users',
+                  id: language_user.id,
+                }
+              end
+          },
+          postcode: if postcode.present? 
+              { 
+                data: {
+                  type: 'postcodes',
+                  id: postcode.id 
+                }
               }
-            else
-              nil
             end
         }
-      }
+      },
+      included: [
+        if postcode.present?
+          postcode.as_json
+        end
+      ]
     }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe User do
+  
+  let(:postcode) { create :postcode }
+  let(:user) { create :user, postcode: postcode }
+
+  describe '#as_json' do
+
+  	it "includes the full Postcode JSON in its JSON response's 'included' key" do
+  	  expect(user.as_json[:included]).to include postcode.as_json
+  	end
+  end
+end

--- a/spec/requests/language_user_spec.rb
+++ b/spec/requests/language_user_spec.rb
@@ -50,7 +50,7 @@ describe "LanguageUser management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'language_users' }
+      it { expect(response_json['data']['type']).to eq 'language_users' }
     end
 
     context "Non-admin creating a LanguageUser on behalf of another user" do
@@ -80,7 +80,7 @@ describe "LanguageUser management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'language_users' }
+      it { expect(response_json['data']['type']).to eq 'language_users' }
     end
 
     context "Owner of this LanguageUser logged in *and* blacklisted" do
@@ -103,12 +103,12 @@ describe "LanguageUser management" do
       let(:admin) { true }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'language_users' }
+      it { expect(response_json['data']['type']).to eq 'language_users' }
     end
 
     context "Owner logged in" do
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'language_users' }
+      it { expect(response_json['data']['type']).to eq 'language_users' }
     end
 
     context "Non-owner logged in" do

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -47,27 +47,27 @@ describe 'POST /signup', type: :request do
       it { expect(response).to have_http_status(200) }
 
       it "saves and returns the email" do
-        expect(response_json['attributes']['email']).to eq tutor_attrs[:email]
+        expect(response_json['data']['attributes']['email']).to eq tutor_attrs[:email]
       end
 
       it "saves and returns the first name" do
-        expect(response_json['attributes']['first_name']).to eq tutor_attrs[:first_name]
+        expect(response_json['data']['attributes']['first_name']).to eq tutor_attrs[:first_name]
       end
 
       it "saves and returns the last name" do
-        expect(response_json['attributes']['last_name']).to eq tutor_attrs[:last_name]
+        expect(response_json['data']['attributes']['last_name']).to eq tutor_attrs[:last_name]
       end
 
       it "saves and returns last_seen (sidestep format issues by comparing both timestamps)" do
-        expect(Time.parse(response_json['attributes']['last_seen']).to_i).to eq tutor_attrs[:last_seen].to_i
+        expect(Time.parse(response_json['data']['attributes']['last_seen']).to_i).to eq tutor_attrs[:last_seen].to_i
       end
 
       it "saves and returns the sex" do
-        expect(response_json['attributes']['sex']).to eq tutor_attrs[:sex]
+        expect(response_json['data']['attributes']['sex']).to eq tutor_attrs[:sex]
       end
 
       it "saves and returns the age" do
-        expect(response_json['attributes']['age']).to eq tutor_attrs[:age]
+        expect(response_json['data']['attributes']['age']).to eq tutor_attrs[:age]
       end
     end
 
@@ -76,7 +76,7 @@ describe 'POST /signup', type: :request do
       before { post '/signup', params: params }
 
       it "saves and returns the postcode ID" do
-        expect(response_json['relationships']['postcode']['data']['id']).to eq postcode.id
+        expect(response_json['data']['relationships']['postcode']['data']['id']).to eq postcode.id
       end
     end
 
@@ -89,7 +89,7 @@ describe 'POST /signup', type: :request do
         it { expect(response).to have_http_status(200) }
 
         it "saves and returns a regular ol' User type" do
-          expect(response_json['type']).to eq 'users'
+          expect(response_json['data']['type']).to eq 'users'
         end
       end
 
@@ -103,19 +103,19 @@ describe 'POST /signup', type: :request do
         it { expect(response).to have_http_status(200) }
 
         it "saves and returns a Tutor type" do
-          expect(response_json['type']).to eq 'tutors'
+          expect(response_json['data']['type']).to eq 'tutors'
         end
 
         it "saves and returns the hourly_rate" do
-          expect(response_json['attributes']['hourly_rate'].to_f).to eq tutor_attrs[:hourly_rate]
+          expect(response_json['data']['attributes']['hourly_rate'].to_f).to eq tutor_attrs[:hourly_rate]
         end
 
         it "saves and returns the max_distance_available" do
-          expect(response_json['attributes']['max_distance_available'].to_f).to eq tutor_attrs[:max_distance_available]
+          expect(response_json['data']['attributes']['max_distance_available'].to_f).to eq tutor_attrs[:max_distance_available]
         end
 
         it "saves and returns the biography" do
-          expect(response_json['attributes']['biography']).to eq tutor_attrs[:biography]
+          expect(response_json['data']['attributes']['biography']).to eq tutor_attrs[:biography]
         end
       end
 
@@ -129,7 +129,7 @@ describe 'POST /signup', type: :request do
         it { expect(response).to have_http_status(200) }
 
         it "saves and returns a Student type" do
-          expect(response_json['type']).to eq 'students'
+          expect(response_json['data']['type']).to eq 'students'
         end
       end
     end

--- a/spec/requests/saved_profile_spec.rb
+++ b/spec/requests/saved_profile_spec.rb
@@ -50,7 +50,7 @@ describe "SavedProfile management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'saved_profiles' }
+      it { expect(response_json['data']['type']).to eq 'saved_profiles' }
     end
 
     context "Non-admin creating a SavedProfile on behalf of another saver" do
@@ -80,7 +80,7 @@ describe "SavedProfile management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'saved_profiles' }
+      it { expect(response_json['data']['type']).to eq 'saved_profiles' }
     end
 
     context "Owner of this SavedProfile logged in *and* blacklisted" do
@@ -103,12 +103,12 @@ describe "SavedProfile management" do
       let(:admin) { true }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'saved_profiles' }
+      it { expect(response_json['data']['type']).to eq 'saved_profiles' }
     end
 
     context "Owner logged in" do
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'saved_profiles' }
+      it { expect(response_json['data']['type']).to eq 'saved_profiles' }
     end
 
     context "Non-owner logged in" do

--- a/spec/requests/signup_spec.rb
+++ b/spec/requests/signup_spec.rb
@@ -12,7 +12,7 @@ describe 'POST /signup', type: :request do
     before { post url, params: params }
 
     it { expect(response.status).to eq 200 }
-    it { expect(JSON.parse(response.body)['attributes']['email']).to eq params[:user][:email] }
+    it { expect(response_json['data']['attributes']['email']).to eq params[:user][:email] }
   end
 
   context 'User already exists in the database' do
@@ -23,6 +23,6 @@ describe 'POST /signup', type: :request do
     }
 
     it { expect(response.status).to eq 400 }
-    it { expect(JSON.parse(response.body)['errors'][0]['title']).to eq('Bad Request') }
+    it { expect(response_json['errors'][0]['title']).to eq('Bad Request') }
   end
 end

--- a/spec/requests/student_subject_spec.rb
+++ b/spec/requests/student_subject_spec.rb
@@ -50,7 +50,7 @@ describe "LanguageUser management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'student_subjects' }
+      it { expect(response_json['data']['type']).to eq 'student_subjects' }
     end
 
     context "Non-admin creating a StudentSubject on behalf of another student" do
@@ -80,7 +80,7 @@ describe "LanguageUser management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'student_subjects' }
+      it { expect(response_json['data']['type']).to eq 'student_subjects' }
     end
 
     context "Owner of this StudentSubject logged in *and* blacklisted" do
@@ -103,12 +103,12 @@ describe "LanguageUser management" do
       let(:admin) { true }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'student_subjects' }
+      it { expect(response_json['data']['type']).to eq 'student_subjects' }
     end
 
     context "Owner logged in" do
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'student_subjects' }
+      it { expect(response_json['data']['type']).to eq 'student_subjects' }
     end
 
     context "Non-owner logged in" do

--- a/spec/requests/subject_tutor_spec.rb
+++ b/spec/requests/subject_tutor_spec.rb
@@ -50,7 +50,7 @@ describe "SubjectTutor management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'subject_tutors' }
+      it { expect(response_json['data']['type']).to eq 'subject_tutors' }
     end
 
     context "Non-admin creating a SubjectTutor on behalf of another saver" do
@@ -80,7 +80,7 @@ describe "SubjectTutor management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'subject_tutors' }
+      it { expect(response_json['data']['type']).to eq 'subject_tutors' }
     end
 
     context "Owner of this SubjectTutor logged in *and* blacklisted" do
@@ -103,12 +103,12 @@ describe "SubjectTutor management" do
       let(:admin) { true }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'subject_tutors' }
+      it { expect(response_json['data']['type']).to eq 'subject_tutors' }
     end
 
     context "Owner logged in" do
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'subject_tutors' }
+      it { expect(response_json['data']['type']).to eq 'subject_tutors' }
     end
 
     context "Non-owner logged in" do

--- a/spec/requests/tutor_availability_spec.rb
+++ b/spec/requests/tutor_availability_spec.rb
@@ -50,7 +50,7 @@ describe "TutorAvailability management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'tutor_availabilities' }
+      it { expect(response_json['data']['type']).to eq 'tutor_availabilities' }
     end
 
     context "Non-admin creating a TutorAvailability on behalf of another tutor" do
@@ -80,7 +80,7 @@ describe "TutorAvailability management" do
       }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'tutor_availabilities' }
+      it { expect(response_json['data']['type']).to eq 'tutor_availabilities' }
     end
 
     context "Owner of this TutorAvailability logged in *and* blacklisted" do
@@ -103,12 +103,12 @@ describe "TutorAvailability management" do
       let(:admin) { true }
 
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'tutor_availabilities' }
+      it { expect(response_json['data']['type']).to eq 'tutor_availabilities' }
     end
 
     context "Owner logged in" do
       it { expect(response.status).to eq 200 }
-      it { expect(response_json['type']).to eq 'tutor_availabilities' }
+      it { expect(response_json['data']['type']).to eq 'tutor_availabilities' }
     end
 
     context "Non-owner logged in" do


### PR DESCRIPTION
Trello card: https://trello.com/c/baLYKeKL/37-add-postcode-full-json-to-tutor-json-response

Two things: extended User#as_json to include its postcode in its 'included' key ...

... And discovered the hard way that I'd introduced a bug into every model's #as_json. I'd implemented each model like this:
```
user_json = {
  id: 1,
  type: 'users',
  attributes: { ... },
  relationships: { ... },
}
```
And it should have been like this:
```
user_json = { 
  data: { 
    id: 1,
    type: 'users', 
    attributes: { ... },
    relationships: { ... },
  },
  included: [{ ... }]
}
```
Oops!

This fixes that.